### PR TITLE
upgrade pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Runtime deps
-Pillow==7.1.*
+Pillow==9.3.*
 reportlab==3.5.*
 
 # code maint


### PR DESCRIPTION
Upgrades Pillow to a newer version because of security vulnerabilities in v7. 

Once merged, I will create a new release tag, and we can update Turnout and the Lambda PDF filler functions to use the new version.