### PR TITLE
upgrade to non-vulnerable version of pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Runtime deps
-Pillow==10.0.*
+Pillow==10.2.*
 reportlab==3.5.*
 
 # code maint


### PR DESCRIPTION
Upgrade Pillow version.

This has been tested by pulling in a version of pdf_template into pdf_filler using Pillow 10.2.0. I was able to successfully get PDFs to fill with Pillow 10.2.0 installed. 